### PR TITLE
chore(arel): remove outdated variable Arel::Visitors::VISITORS

### DIFF
--- a/lib/arel/visitors/hana.rb
+++ b/lib/arel/visitors/hana.rb
@@ -7,5 +7,3 @@ module Arel
     end
   end
 end
-
-Arel::Visitors::VISITORS['hana'] = Arel::Visitors::Hana


### PR DESCRIPTION
reason: https://github.com/rails/arel/commit/62e3596db89570b9d48b13c9966d754d5859d0dc#diff-e53edfe0dc990ee54addfcc9232219ee

For example, application based on rails 5.2.2 can't establish connection through hana adapter because variable VISITORS is absent

As I understand, this variable is unused in Arel for last several years